### PR TITLE
Add app.kubernetes.io/part-of

### DIFF
--- a/tap/workload.yaml
+++ b/tap/workload.yaml
@@ -3,6 +3,7 @@ kind: Workload
 metadata:
   name: spring-sensors
   labels:
+    app.kubernetes.io/part-of: spring-sensors
     apps.tanzu.vmware.com/workload-type: web
 spec:
   source:


### PR DESCRIPTION
Required to make Runtime Resources available in TAP-GUI
